### PR TITLE
:bug: deserializeValues -> deserializeValue for single variable

### DIFF
--- a/django_camunda/api.py
+++ b/django_camunda/api.py
@@ -47,7 +47,7 @@ def _get_variable(kind: str, id_ref: CamundaId, name: str) -> Any:
     client = get_client()
     path = f"{kind}/{id_ref}/variables/{name}"
     response_data = client.get(
-        path, params={"deserializeValues": "false"}, underscoreize=False
+        path, params={"deserializeValue": "false"}, underscoreize=False
     )
     return deserialize_variable(response_data)
 


### PR DESCRIPTION
The query parameter for deserializing values of variables should be singular if a single variable is retrieved. See the camunda docs https://docs.camunda.org/manual/7.16/reference/rest/task/variables/get-task-variable/