### PR TITLE
[#2601] disable autocomplete for username/password fields

### DIFF
--- a/django_camunda/forms.py
+++ b/django_camunda/forms.py
@@ -24,7 +24,8 @@ class CamundaConfigForm(forms.ModelForm):
         label=_("Password"),
         required=False,
         help_text=_("Password to authenticate against the Camunda API."),
-        widget=forms.PasswordInput,
+        # turn off autocomplete: https://stackoverflow.com/q/33113891
+        widget=forms.PasswordInput(attrs={"autocomplete": "new-password"}),
     )
 
     class Meta:


### PR DESCRIPTION
Closes open-formulieren/open-forms#2601 (complements [PR #2637](https://github.com/open-formulieren/open-forms/pull/2637)

* Disable autocomplete for username/password fields in the Camunda configuration admin